### PR TITLE
Do not override user preferences

### DIFF
--- a/ftplugin/wdl.vim
+++ b/ftplugin/wdl.vim
@@ -1,5 +1,1 @@
 setlocal commentstring=//\ %s
-" @-@ adds the literal @ to iskeyword for @IBAction and similar
-setlocal tabstop=2
-setlocal softtabstop=2
-setlocal shiftwidth=2


### PR DESCRIPTION
The indent width is, except in rare circumstances, not tied to the language but rather a user preference that should be configurable in the user’s `.vimrc` file. Filetype plugins should generally *not* override this setting.

This PR ensures that user settings are respected.