### PR TITLE
Fix `commentstring`

### DIFF
--- a/ftplugin/wdl.vim
+++ b/ftplugin/wdl.vim
@@ -1,4 +1,4 @@
-setlocal commentstring=//\ %s
+setlocal commentstring=#\ %s
 " @-@ adds the literal @ to iskeyword for @IBAction and similar
 setlocal tabstop=2
 setlocal softtabstop=2


### PR DESCRIPTION
Comments in WDL start with `#` but the syntax definition for comment strings erroneously used `//`. This PR fixes that.